### PR TITLE
Make the radio interrupt handler preemptable

### DIFF
--- a/Firmware/radio/main.c
+++ b/Firmware/radio/main.c
@@ -259,8 +259,10 @@ hardware_init(void)
 	// UART - set the configured speed
 	serial_init(param_get(PARAM_SERIAL_SPEED));
 
-	// set all interrupts to the same priority level
-	IP = 0;
+	// set interrupt priority level
+	IP = 0;  // default low priority
+	PS0 = 1; // UART0 high priority
+	PT2 = 1; // TIMER2 high priority
 
 	// global interrupt enable
 	EA = 1;


### PR DESCRIPTION
Adjust interrupt priorities such that the radio interrupt handler can be preempted by the other two kinds of interrupts. This is important because at least on Si1060-based modems the radio handler can take so long we occasionally miss bytes on the serial RX line.