### PR TITLE
Streamline scripts in Firmware/tools.

### DIFF
--- a/Firmware/tools/README.md
+++ b/Firmware/tools/README.md
@@ -1,0 +1,1 @@
+To install script dependencies, run `pip install -r requirements.txt`.

--- a/Firmware/tools/atcommander.py
+++ b/Firmware/tools/atcommander.py
@@ -3,7 +3,8 @@
 # Provide command line access to AT command set on radios
 #
 
-import serial, sys, argparse, time, fdpexpect
+import serial, sys, argparse, time, pexpect
+from pexpect import fdpexpect
 
 class ATCommandSet(object):
     ''' Interface to the AT command set '''

--- a/Firmware/tools/console.py
+++ b/Firmware/tools/console.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # a trivial serial console
 
-import serial, sys, optparse, fdpexpect
+import serial, sys, optparse, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("console")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/requirements.txt
+++ b/Firmware/tools/requirements.txt
@@ -1,0 +1,11 @@
+future==0.17.1
+iso8601==0.1.12
+lxml==4.3.1
+pexpect==4.6.0
+ptyprocess==0.6.0
+pycairo==1.18.0
+PyGObject==3.30.4
+pymavlink==2.3.4
+pyserial==3.4
+PyYAML==3.13
+serial==0.0.97

--- a/Firmware/tools/rssi.py
+++ b/Firmware/tools/rssi.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # RSSI production test
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("update_mode")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/set_speed.py
+++ b/Firmware/tools/set_speed.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("set_speed")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/set_sreg.py
+++ b/Firmware/tools/set_sreg.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("set_speed")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/show_regs.py
+++ b/Firmware/tools/show_regs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("show_regs")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/show_rssi.py
+++ b/Firmware/tools/show_rssi.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("show_rssi")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/update_mode.py
+++ b/Firmware/tools/update_mode.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # put a HopeRF into update mode
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("update_mode")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')


### PR DESCRIPTION
New:

* Add a requirements.txt to specify script dependencies.
* Add import of pexpect and correct import of fdpexpect.