### PR TITLE
Restore 30MHz Si1060 configuration headers

### DIFF
--- a/data/conf_Si1060_30MHz/433_128kbps.h
+++ b/data/conf_Si1060_30MHz/433_128kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 128000    Fdev(Hz): 128125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 412.25 kHz);  NB-filter 2 (BW = 412.25 kHz)
+// 
+// Modulation index: 2.002
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x27, 0x10, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x22
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xFD
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0x80, 0x00, 0x00, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x75, 0x04, 0x5E, 0x7B, 0x02, 0x30, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x47, 0x82, 0xEA, 0x02, 0xC2, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1A, 0x1A, 0x00, 0x1A, 0x80, 0x20, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x01, 0x47, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x39, 0x04, 0x0B, 0x05, 0x04, 0x01, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_16kbps.h
+++ b/data/conf_Si1060_30MHz/433_16kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 16000    Fdev(Hz): 16250    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 4 (BW =  82.64 kHz);  NB-filter 4 (BW = 82.64 kHz)
+// 
+// Modulation index: 2.031
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x09, 0xC4, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x04
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x70
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0x80, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0xEA, 0x02, 0x2F, 0x3E, 0x01, 0x18, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x2F, 0x09, 0xE2, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x33, 0x33, 0x00, 0x1A, 0x82, 0x00, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x8D, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_192kbps.h
+++ b/data/conf_Si1060_30MHz/433_192kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 192000    Fdev(Hz): 158750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 6 (BW = 535.40 kHz);  NB-filter 6 (BW = 535.40 kHz)
+// 
+// Modulation index: 1.654
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x3A, 0x98, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x2B
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x59
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x00, 0x30
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xFC, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x23, 0x8D, 0x1B, 0x01, 0x1E, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x22, 0x11, 0x11, 0x00, 0x1A, 0x69, 0xD5, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xCB, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0x5B, 0x47, 0x0F, 0xC0, 0x6D, 0x25, 0xF4, 0xDB, 0xD6, 0xDF, 0xEC, 0xF7
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFE, 0x01, 0x15, 0xF0, 0xFF, 0x03, 0x5B, 0x47, 0x0F, 0xC0, 0x6D, 0x25
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xF4, 0xDB, 0xD6, 0xDF, 0xEC, 0xF7, 0xFE, 0x01, 0x15, 0xF0, 0xFF, 0x03
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x5D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x39, 0x04, 0x0B, 0x05, 0x04, 0x01, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_19kbps.h
+++ b/data/conf_Si1060_30MHz/433_19kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 19000    Fdev(Hz): 18750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW =  68.71 kHz);  NB-filter 2 (BW = 68.71 kHz)
+// 
+// Modulation index: 1.974
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0B, 0x98, 0xC0, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x05
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x1F
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x20, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x84, 0x03, 0xE4, 0x26, 0x01, 0xF7, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0xA6, 0x03, 0x29, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1D, 0x1D, 0x00, 0x1A, 0x7E, 0x51, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x01, 0x20, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_24kbps.h
+++ b/data/conf_Si1060_30MHz/433_24kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 24000    Fdev(Hz): 23750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW =  76.31 kHz);  NB-filter 1 (BW = 76.31 kHz)
+// 
+// Modulation index: 1.979
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0E, 0xA6, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x06
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x7C
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x20, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x68, 0x04, 0xEA, 0x4B, 0x02, 0x7D, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0xD2, 0x02, 0xC5, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x17, 0x17, 0x00, 0x1A, 0x7E, 0xAB, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x01, 0x6C, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_250kbps.h
+++ b/data/conf_Si1060_30MHz/433_250kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 250000    Fdev(Hz): 158750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 5 (BW = 593.60 kHz);  NB-filter 5 (BW = 593.60 kHz)
+// 
+// Modulation index: 1.27
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x26, 0x25, 0xA0, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x2B
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x59
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x00, 0x30
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x78, 0x04, 0x44, 0x44, 0x03, 0x5C, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x23, 0x8F, 0xFF, 0x00, 0xF6, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x22, 0x0D, 0x0D, 0x00, 0x1A, 0x51, 0x48, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xCB, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0x7E, 0x64, 0x1B, 0xBA, 0x58, 0x0B, 0xDD, 0xCE, 0xD6, 0xE6, 0xF6, 0x00
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x03, 0x15, 0xF0, 0x3F, 0x00, 0x7E, 0x64, 0x1B, 0xBA, 0x58, 0x0B
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xDD, 0xCE, 0xD6, 0xE6, 0xF6, 0x00, 0x03, 0x03, 0x15, 0xF0, 0x3F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x5D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x01, 0x05, 0x0B, 0x05, 0x02, 0x00, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_2kbps.h
+++ b/data/conf_Si1060_30MHz/433_2kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 2000    Fdev(Hz): 1875    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW =  38.15 kHz);  NB-filter 1 (BW = 38.15 kHz)
+// 
+// Modulation index: 1.875
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x01, 0x38, 0x80, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x83
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x30, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x02, 0x71, 0x00, 0xD1, 0xB7, 0x00, 0x70, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x11, 0x11, 0x2F, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x89, 0x89, 0x00, 0x1A, 0x78, 0x00, 0x00, 0x2B
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0x3A, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_32kbps.h
+++ b/data/conf_Si1060_30MHz/433_32kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 32000    Fdev(Hz): 31875    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 103.06 kHz);  NB-filter 2 (BW = 103.06 kHz)
+// 
+// Modulation index: 1.992
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x09, 0xC4, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x08
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xB4
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x75, 0x04, 0x5E, 0x7B, 0x02, 0x32, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x81, 0x18, 0x02, 0xCC, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1A, 0x1A, 0x00, 0x1A, 0x7F, 0x80, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x01, 0x46, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_48kbps.h
+++ b/data/conf_Si1060_30MHz/433_48kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 48000    Fdev(Hz): 48125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 4 (BW = 165.28 kHz);  NB-filter 4 (BW = 165.28 kHz)
+// 
+// Modulation index: 2.005
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0E, 0xA6, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x0D
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x24
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0x80, 0x00, 0x10, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA4, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x8C, 0x06, 0x8D, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x80, 0x55, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0xD0, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_4kbps.h
+++ b/data/conf_Si1060_30MHz/433_4kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 4000    Fdev(Hz): 3750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 4 (BW =  41.32 kHz);  NB-filter 4 (BW = 41.32 kHz)
+// 
+// Modulation index: 1.875
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x02, 0x71, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x01
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x06
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x30, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x01, 0xD5, 0x01, 0x17, 0x9F, 0x00, 0x95, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x23, 0x09, 0x09, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x67, 0x67, 0x00, 0x1A, 0x78, 0x00, 0x00, 0x2A
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0x4D, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_64kbps.h
+++ b/data/conf_Si1060_30MHz/433_64kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 64000    Fdev(Hz): 63750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 206.12 kHz);  NB-filter 2 (BW = 206.12 kHz)
+// 
+// Modulation index: 1.992
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x13, 0x88, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x11
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x68
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0x80, 0x00, 0x10, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x75, 0x04, 0x5E, 0x7B, 0x02, 0x32, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x82, 0x2F, 0x02, 0xC5, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1A, 0x1A, 0x00, 0x1A, 0x7F, 0x80, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x01, 0x46, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_8kbps.h
+++ b/data/conf_Si1060_30MHz/433_8kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 8000    Fdev(Hz): 8125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW =  57.23 kHz);  NB-filter 1 (BW = 57.23 kHz)
+// 
+// Modulation index: 2.031
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x04, 0xE2, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x02
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x38
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0x80, 0x00, 0x30, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0xEA, 0x02, 0x2F, 0x3E, 0x01, 0x18, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x17, 0x0E, 0x0A, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x33, 0x33, 0x00, 0x1A, 0x82, 0x00, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x8D, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/433_96kbps.h
+++ b/data/conf_Si1060_30MHz/433_96kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 96000    Fdev(Hz): 96250    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW = 305.23 kHz);  NB-filter 1 (BW = 305.23 kHz)
+// 
+// Modulation index: 2.005
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x1D, 0x4C, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x1A
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x48
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0x80, 0x00, 0x00, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x68, 0x04, 0xEA, 0x4B, 0x02, 0x76, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x81, 0x18, 0x05, 0xEC, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x17, 0x17, 0x00, 0x1A, 0x80, 0x55, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x01, 0x71, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x0A
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x34, 0x04, 0x0B, 0x04, 0x07, 0x70, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0D, 0xDD, 0xDD, 0x44, 0x44, 0x20, 0xFE
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_128kbps.h
+++ b/data/conf_Si1060_30MHz/868_128kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 128000    Fdev(Hz): 128125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW = 457.85 kHz);  NB-filter 1 (BW = 457.85 kHz)
+// 
+// Modulation index: 2.002
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x27, 0x10, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x11
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x7E
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x75, 0x04, 0x5E, 0x7B, 0x02, 0x30, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x47, 0x81, 0x75, 0x03, 0x10, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1A, 0x1A, 0x00, 0x1A, 0x80, 0x20, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x01, 0x47, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x39, 0x04, 0x0B, 0x05, 0x04, 0x01, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_16kbps.h
+++ b/data/conf_Si1060_30MHz/868_16kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 16000    Fdev(Hz): 16250    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW = 114.46 kHz);  NB-filter 1 (BW = 114.46 kHz)
+// 
+// Modulation index: 2.031
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x09, 0xC4, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x02
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x38
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0xEA, 0x02, 0x2F, 0x3E, 0x01, 0x18, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x17, 0x0D, 0xEB, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x33, 0x33, 0x00, 0x1A, 0x82, 0x00, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x8D, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_192kbps.h
+++ b/data/conf_Si1060_30MHz/868_192kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 192000    Fdev(Hz): 158750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 6 (BW = 535.40 kHz);  NB-filter 6 (BW = 535.40 kHz)
+// 
+// Modulation index: 1.654
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x3A, 0x98, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x15
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xAD
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x30
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xFC, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x23, 0x86, 0x8E, 0x01, 0x1D, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x22, 0x11, 0x11, 0x00, 0x1A, 0x69, 0xD5, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xCB, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0x5B, 0x47, 0x0F, 0xC0, 0x6D, 0x25, 0xF4, 0xDB, 0xD6, 0xDF, 0xEC, 0xF7
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFE, 0x01, 0x15, 0xF0, 0xFF, 0x03, 0x5B, 0x47, 0x0F, 0xC0, 0x6D, 0x25
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xF4, 0xDB, 0xD6, 0xDF, 0xEC, 0xF7, 0xFE, 0x01, 0x15, 0xF0, 0xFF, 0x03
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x5D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x39, 0x04, 0x0B, 0x05, 0x04, 0x01, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_19kbps.h
+++ b/data/conf_Si1060_30MHz/868_19kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 19000    Fdev(Hz): 18750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 103.06 kHz);  NB-filter 2 (BW = 103.06 kHz)
+// 
+// Modulation index: 1.974
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0B, 0x98, 0xC0, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x02
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x8F
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0xC5, 0x02, 0x98, 0x19, 0x01, 0x51, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x53, 0x04, 0xB8, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x2B, 0x2B, 0x00, 0x1A, 0x7E, 0x51, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xC0, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_24kbps.h
+++ b/data/conf_Si1060_30MHz/868_24kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 24000    Fdev(Hz): 23750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW = 114.46 kHz);  NB-filter 1 (BW = 114.46 kHz)
+// 
+// Modulation index: 1.979
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0E, 0xA6, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x03
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x3E
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA9, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x69, 0x04, 0x23, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x7E, 0xAB, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xF3, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_250kbps.h
+++ b/data/conf_Si1060_30MHz/868_250kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 250000    Fdev(Hz): 158750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 5 (BW = 593.60 kHz);  NB-filter 5 (BW = 593.60 kHz)
+// 
+// Modulation index: 1.27
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x26, 0x25, 0xA0, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x15
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xAD
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x30
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x78, 0x04, 0x44, 0x44, 0x03, 0x5C, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x23, 0x88, 0x89, 0x00, 0xF3, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x22, 0x0D, 0x0D, 0x00, 0x1A, 0x51, 0x48, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xCB, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0x7E, 0x64, 0x1B, 0xBA, 0x58, 0x0B, 0xDD, 0xCE, 0xD6, 0xE6, 0xF6, 0x00
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x03, 0x15, 0xF0, 0x3F, 0x00, 0x7E, 0x64, 0x1B, 0xBA, 0x58, 0x0B
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xDD, 0xCE, 0xD6, 0xE6, 0xF6, 0x00, 0x03, 0x03, 0x15, 0xF0, 0x3F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x5D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x01, 0x05, 0x0B, 0x05, 0x02, 0x00, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_2kbps.h
+++ b/data/conf_Si1060_30MHz/868_2kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 2000    Fdev(Hz): 1875    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW =  76.31 kHz);  NB-filter 1 (BW = 76.31 kHz)
+// 
+// Modulation index: 1.875
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x01, 0x38, 0x80, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x42
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x04, 0xE2, 0x00, 0x68, 0xDC, 0x00, 0x34, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x03, 0x4C, 0x1F, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0xFF, 0xFF, 0x00, 0x1A, 0x78, 0x00, 0x00, 0x2B
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x1D, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_32kbps.h
+++ b/data/conf_Si1060_30MHz/868_32kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 32000    Fdev(Hz): 31875    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 3 (BW = 123.48 kHz);  NB-filter 3 (BW = 123.48 kHz)
+// 
+// Modulation index: 1.992
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x09, 0xC4, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x04
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x5A
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA6, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x8C, 0x03, 0x58, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x7F, 0x80, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xF4, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_48kbps.h
+++ b/data/conf_Si1060_30MHz/868_48kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 48000    Fdev(Hz): 48125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 206.12 kHz);  NB-filter 2 (BW = 206.12 kHz)
+// 
+// Modulation index: 2.005
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0E, 0xA6, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x06
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x92
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA4, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x46, 0x08, 0x1F, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x80, 0x55, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0xD0, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_4kbps.h
+++ b/data/conf_Si1060_30MHz/868_4kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 4000    Fdev(Hz): 3750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW =  76.31 kHz);  NB-filter 1 (BW = 76.31 kHz)
+// 
+// Modulation index: 1.875
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x02, 0x71, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x83
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x02, 0x71, 0x00, 0xD1, 0xB7, 0x00, 0x70, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x11, 0x11, 0x1D, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x89, 0x89, 0x00, 0x1A, 0x78, 0x00, 0x00, 0x2B
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0x3A, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_64kbps.h
+++ b/data/conf_Si1060_30MHz/868_64kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 64000    Fdev(Hz): 63750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 206.12 kHz);  NB-filter 2 (BW = 206.12 kHz)
+// 
+// Modulation index: 1.992
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x13, 0x88, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x08
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xB4
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x75, 0x04, 0x5E, 0x7B, 0x02, 0x32, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x81, 0x18, 0x02, 0xC4, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1A, 0x1A, 0x00, 0x1A, 0x7F, 0x80, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x01, 0x46, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_8kbps.h
+++ b/data/conf_Si1060_30MHz/868_8kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 8000    Fdev(Hz): 8125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 3 (BW =  92.61 kHz);  NB-filter 3 (BW = 92.61 kHz)
+// 
+// Modulation index: 2.031
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x04, 0xE2, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x01
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x1C
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x01, 0xD5, 0x01, 0x17, 0x9F, 0x00, 0x8C, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x0C, 0x15, 0xA8, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x67, 0x67, 0x00, 0x1A, 0x82, 0x00, 0x00, 0x2A
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x46, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/868_96kbps.h
+++ b/data/conf_Si1060_30MHz/868_96kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 96000    Fdev(Hz): 96250    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 868    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 4 (BW = 330.55 kHz);  NB-filter 4 (BW = 330.55 kHz)
+// 
+// Modulation index: 2.005
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x1D, 0x4C, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x0D
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x24
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA4, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x8C, 0x06, 0x63, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x80, 0x55, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0xD0, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x34, 0x04, 0x0B, 0x04, 0x07, 0x70, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x38, 0x0E, 0xEE, 0xEE, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_128kbps.h
+++ b/data/conf_Si1060_30MHz/915_128kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 128000    Fdev(Hz): 128125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW = 457.85 kHz);  NB-filter 1 (BW = 457.85 kHz)
+// 
+// Modulation index: 2.002
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x27, 0x10, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x11
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x7E
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x75, 0x04, 0x5E, 0x7B, 0x02, 0x30, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x47, 0x81, 0x75, 0x03, 0x10, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1A, 0x1A, 0x00, 0x1A, 0x80, 0x20, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x01, 0x47, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x39, 0x04, 0x0B, 0x05, 0x04, 0x01, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_16kbps.h
+++ b/data/conf_Si1060_30MHz/915_16kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 16000    Fdev(Hz): 16250    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW = 114.46 kHz);  NB-filter 1 (BW = 114.46 kHz)
+// 
+// Modulation index: 2.031
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x09, 0xC4, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x02
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x38
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0xEA, 0x02, 0x2F, 0x3E, 0x01, 0x18, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x17, 0x0E, 0x34, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x33, 0x33, 0x00, 0x1A, 0x82, 0x00, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x8D, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_192kbps.h
+++ b/data/conf_Si1060_30MHz/915_192kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 192000    Fdev(Hz): 158750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 6 (BW = 535.40 kHz);  NB-filter 6 (BW = 535.40 kHz)
+// 
+// Modulation index: 1.654
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x3A, 0x98, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x15
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xAD
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x30
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xFC, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x23, 0x86, 0x8E, 0x01, 0x1D, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x22, 0x11, 0x11, 0x00, 0x1A, 0x69, 0xD5, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xCB, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0x5B, 0x47, 0x0F, 0xC0, 0x6D, 0x25, 0xF4, 0xDB, 0xD6, 0xDF, 0xEC, 0xF7
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFE, 0x01, 0x15, 0xF0, 0xFF, 0x03, 0x5B, 0x47, 0x0F, 0xC0, 0x6D, 0x25
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xF4, 0xDB, 0xD6, 0xDF, 0xEC, 0xF7, 0xFE, 0x01, 0x15, 0xF0, 0xFF, 0x03
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x5D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x39, 0x04, 0x0B, 0x05, 0x04, 0x01, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_19kbps.h
+++ b/data/conf_Si1060_30MHz/915_19kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 19000    Fdev(Hz): 18750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 103.06 kHz);  NB-filter 2 (BW = 103.06 kHz)
+// 
+// Modulation index: 1.974
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0B, 0x98, 0xC0, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x02
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x8F
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0xC5, 0x02, 0x98, 0x19, 0x01, 0x51, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x53, 0x04, 0xB8, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x2B, 0x2B, 0x00, 0x1A, 0x7E, 0x51, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xC0, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_24kbps.h
+++ b/data/conf_Si1060_30MHz/915_24kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 24000    Fdev(Hz): 23750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 1 (BW = 114.46 kHz);  NB-filter 1 (BW = 114.46 kHz)
+// 
+// Modulation index: 1.979
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0E, 0xA6, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x03
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x3E
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA9, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x69, 0x04, 0x23, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x7E, 0xAB, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xF3, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_250kbps.h
+++ b/data/conf_Si1060_30MHz/915_250kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 250000    Fdev(Hz): 158750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 5 (BW = 593.60 kHz);  NB-filter 5 (BW = 593.60 kHz)
+// 
+// Modulation index: 1.27
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x26, 0x25, 0xA0, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x15
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xAD
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x30
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x78, 0x04, 0x44, 0x44, 0x03, 0x5C, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x23, 0x88, 0x89, 0x00, 0xF3, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x22, 0x0D, 0x0D, 0x00, 0x1A, 0x51, 0x48, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xCB, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0x7E, 0x64, 0x1B, 0xBA, 0x58, 0x0B, 0xDD, 0xCE, 0xD6, 0xE6, 0xF6, 0x00
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x03, 0x15, 0xF0, 0x3F, 0x00, 0x7E, 0x64, 0x1B, 0xBA, 0x58, 0x0B
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xDD, 0xCE, 0xD6, 0xE6, 0xF6, 0x00, 0x03, 0x03, 0x15, 0xF0, 0x3F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x5D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x01, 0x05, 0x0B, 0x05, 0x02, 0x00, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_2kbps.h
+++ b/data/conf_Si1060_30MHz/915_2kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 2000    Fdev(Hz): 1875    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 4 (BW =  82.64 kHz);  NB-filter 4 (BW = 82.64 kHz)
+// 
+// Modulation index: 1.875
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x01, 0x38, 0x80, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x42
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x07, 0x53, 0x00, 0x45, 0xE8, 0x00, 0x23, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x03, 0x4D, 0x1E, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0xFF, 0xFF, 0x00, 0x1A, 0x78, 0x00, 0x00, 0x2B
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x13, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_32kbps.h
+++ b/data/conf_Si1060_30MHz/915_32kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 32000    Fdev(Hz): 31875    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 3 (BW = 123.48 kHz);  NB-filter 3 (BW = 123.48 kHz)
+// 
+// Modulation index: 1.992
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x09, 0xC4, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x04
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x5A
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x10
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA6, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x8C, 0x03, 0x58, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x7F, 0x80, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0xF4, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_48kbps.h
+++ b/data/conf_Si1060_30MHz/915_48kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 48000    Fdev(Hz): 48125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 206.12 kHz);  NB-filter 2 (BW = 206.12 kHz)
+// 
+// Modulation index: 2.005
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x0E, 0xA6, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x06
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x92
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA4, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x46, 0x08, 0x1F, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x80, 0x55, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0xD0, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_4kbps.h
+++ b/data/conf_Si1060_30MHz/915_4kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 4000    Fdev(Hz): 3750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 4 (BW =  82.64 kHz);  NB-filter 4 (BW = 82.64 kHz)
+// 
+// Modulation index: 1.875
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x02, 0x71, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x83
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x03, 0xAA, 0x00, 0x8B, 0xCF, 0x00, 0x4B, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x80, 0x11, 0x12, 0x85, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0xCD, 0xCD, 0x00, 0x1A, 0x78, 0x00, 0x00, 0x2B
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x00, 0x26, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00, 0xA2, 0x81, 0x26, 0xAF, 0x3F, 0xEE
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xC8, 0xC7, 0xDB, 0xF2, 0x02, 0x08, 0x07, 0x03, 0x15, 0xFC, 0x0F, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_64kbps.h
+++ b/data/conf_Si1060_30MHz/915_64kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 64000    Fdev(Hz): 63750    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 206.12 kHz);  NB-filter 2 (BW = 206.12 kHz)
+// 
+// Modulation index: 1.992
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x13, 0x88, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x08
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0xB4
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x75, 0x04, 0x5E, 0x7B, 0x02, 0x32, 0x02, 0x00
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x00, 0x12, 0x81, 0x18, 0x02, 0xC4, 0xA0
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x1A, 0x1A, 0x00, 0x1A, 0x7F, 0x80, 0x00, 0x28
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x03, 0xD6, 0x03, 0x01, 0x46, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_8kbps.h
+++ b/data/conf_Si1060_30MHz/915_8kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 8000    Fdev(Hz): 8125    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 2 (BW = 103.06 kHz);  NB-filter 2 (BW = 103.06 kHz)
+// 
+// Modulation index: 2.031
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x04, 0xE2, 0x00, 0x05, 0xC9, 0xC3, 0x80, 0x00, 0x01
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x1C
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x20, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x01, 0xD5, 0x01, 0x17, 0x9F, 0x00, 0x8C, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x0C, 0x18, 0x0F, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x67, 0x67, 0x00, 0x1A, 0x82, 0x00, 0x00, 0x2A
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0x46, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/data/conf_Si1060_30MHz/915_96kbps.h
+++ b/data/conf_Si1060_30MHz/915_96kbps.h
@@ -1,0 +1,640 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si1060 Rev.: A0                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 20    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 3    Rsymb(sps): 96000    Fdev(Hz): 96250    RXBW(Hz): 150000    Manchester: 0    AFC_en: 0    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 915    API_TC: 29    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 1    
+// 
+// # RX IF frequency is  -468750 Hz
+// # WB filter 3 (BW = 370.45 kHz);  NB-filter 3 (BW = 370.45 kHz)
+// 
+// Modulation index: 2.005
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x07
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_XO_TUNE_2
+// Number of properties:     2
+// Group ID:                 0x00
+// Start ID:                 0x00
+// Default values:           0x40, 0x00, 
+// Descriptions:
+//   GLOBAL_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+//   GLOBAL_CLK_CFG - Clock configuration options.
+*/
+#define RF_GLOBAL_XO_TUNE_2 0x11, 0x00, 0x02, 0x00, 0x52, 0x00
+
+/*
+// Set properties:           RF_GLOBAL_CONFIG_1
+// Number of properties:     1
+// Group ID:                 0x00
+// Start ID:                 0x03
+// Default values:           0x20, 
+// Descriptions:
+//   GLOBAL_CONFIG - Global configuration settings.
+*/
+#define RF_GLOBAL_CONFIG_1 0x11, 0x00, 0x01, 0x03, 0x60
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x01, 0x38
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PREAMBLE_TX_LENGTH_9
+// Number of properties:     9
+// Group ID:                 0x10
+// Start ID:                 0x00
+// Default values:           0x08, 0x14, 0x00, 0x0F, 0x21, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PREAMBLE_TX_LENGTH - Configure length of TX Preamble.
+//   PREAMBLE_CONFIG_STD_1 - Configuration of reception of a packet with a Standard Preamble pattern.
+//   PREAMBLE_CONFIG_NSTD - Configuration of transmission/reception of a packet with a Non-Standard Preamble pattern.
+//   PREAMBLE_CONFIG_STD_2 - Configuration of timeout periods during reception of a packet with Standard Preamble pattern.
+//   PREAMBLE_CONFIG - General configuration bits for the Preamble field.
+//   PREAMBLE_PATTERN_31_24 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_23_16 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_15_8 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+//   PREAMBLE_PATTERN_7_0 - Configuration of the bit values describing a Non-Standard Preamble pattern.
+*/
+#define RF_PREAMBLE_TX_LENGTH_9 0x11, 0x10, 0x09, 0x00, 0x08, 0x14, 0x00, 0x0F, 0x31, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_SYNC_CONFIG_5
+// Number of properties:     5
+// Group ID:                 0x11
+// Start ID:                 0x00
+// Default values:           0x01, 0x2D, 0xD4, 0x2D, 0xD4, 
+// Descriptions:
+//   SYNC_CONFIG - Sync Word configuration bits.
+//   SYNC_BITS_31_24 - Sync word.
+//   SYNC_BITS_23_16 - Sync word.
+//   SYNC_BITS_15_8 - Sync word.
+//   SYNC_BITS_7_0 - Sync word.
+*/
+#define RF_SYNC_CONFIG_5 0x11, 0x11, 0x05, 0x00, 0x01, 0xB4, 0x2B, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_CRC_CONFIG_7
+// Number of properties:     7
+// Group ID:                 0x12
+// Start ID:                 0x00
+// Default values:           0x00, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   PKT_CRC_CONFIG - Select a CRC polynomial and seed.
+//   PKT_WHT_POLY_15_8 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_POLY_7_0 - 16-bit polynomial value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_15_8 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_SEED_7_0 - 16-bit seed value for the PN Generator (e.g., for Data Whitening)
+//   PKT_WHT_BIT_NUM - Selects which bit of the LFSR (used to generate the PN / data whitening sequence) is used as the output bit for data scrambling.
+//   PKT_CONFIG1 - General configuration bits for transmission or reception of a packet.
+*/
+#define RF_PKT_CRC_CONFIG_7 0x11, 0x12, 0x07, 0x00, 0x84, 0x01, 0x08, 0xFF, 0xFF, 0x00, 0x02
+
+/*
+// Set properties:           RF_PKT_LEN_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x08
+// Default values:           0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_LEN - Configuration bits for reception of a variable length packet.
+//   PKT_LEN_FIELD_SOURCE - Field number containing the received packet length byte(s).
+//   PKT_LEN_ADJUST - Provides for adjustment/offset of the received packet length value (in order to accommodate a variety of methods of defining total packet length).
+//   PKT_TX_THRESHOLD - TX FIFO almost empty threshold.
+//   PKT_RX_THRESHOLD - RX FIFO Almost Full threshold.
+//   PKT_FIELD_1_LENGTH_12_8 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_LENGTH_7_0 - Unsigned 13-bit Field 1 length value.
+//   PKT_FIELD_1_CONFIG - General data processing and packet configuration bits for Field 1.
+//   PKT_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across Field 1.
+//   PKT_FIELD_2_LENGTH_12_8 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_LENGTH_7_0 - Unsigned 13-bit Field 2 length value.
+//   PKT_FIELD_2_CONFIG - General data processing and packet configuration bits for Field 2.
+*/
+#define RF_PKT_LEN_12 0x11, 0x12, 0x0C, 0x08, 0x00, 0x00, 0x00, 0x30, 0x30, 0x00, 0x07, 0x04, 0x80, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_2_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x14
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across Field 2.
+//   PKT_FIELD_3_LENGTH_12_8 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_LENGTH_7_0 - Unsigned 13-bit Field 3 length value.
+//   PKT_FIELD_3_CONFIG - General data processing and packet configuration bits for Field 3.
+//   PKT_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across Field 3.
+//   PKT_FIELD_4_LENGTH_12_8 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_LENGTH_7_0 - Unsigned 13-bit Field 4 length value.
+//   PKT_FIELD_4_CONFIG - General data processing and packet configuration bits for Field 4.
+//   PKT_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across Field 4.
+//   PKT_FIELD_5_LENGTH_12_8 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_LENGTH_7_0 - Unsigned 13-bit Field 5 length value.
+//   PKT_FIELD_5_CONFIG - General data processing and packet configuration bits for Field 5.
+*/
+#define RF_PKT_FIELD_2_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_FIELD_5_CRC_CONFIG_12
+// Number of properties:     12
+// Group ID:                 0x12
+// Start ID:                 0x20
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across Field 5.
+//   PKT_RX_FIELD_1_LENGTH_12_8 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_LENGTH_7_0 - Unsigned 13-bit RX Field 1 length value.
+//   PKT_RX_FIELD_1_CONFIG - General data processing and packet configuration bits for RX Field 1.
+//   PKT_RX_FIELD_1_CRC_CONFIG - Configuration of CRC control bits across RX Field 1.
+//   PKT_RX_FIELD_2_LENGTH_12_8 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_LENGTH_7_0 - Unsigned 13-bit RX Field 2 length value.
+//   PKT_RX_FIELD_2_CONFIG - General data processing and packet configuration bits for RX Field 2.
+//   PKT_RX_FIELD_2_CRC_CONFIG - Configuration of CRC control bits across RX Field 2.
+//   PKT_RX_FIELD_3_LENGTH_12_8 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_LENGTH_7_0 - Unsigned 13-bit RX Field 3 length value.
+//   PKT_RX_FIELD_3_CONFIG - General data processing and packet configuration bits for RX Field 3.
+*/
+#define RF_PKT_FIELD_5_CRC_CONFIG_12 0x11, 0x12, 0x0C, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_PKT_RX_FIELD_3_CRC_CONFIG_9
+// Number of properties:     9
+// Group ID:                 0x12
+// Start ID:                 0x2C
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   PKT_RX_FIELD_3_CRC_CONFIG - Configuration of CRC control bits across RX Field 3.
+//   PKT_RX_FIELD_4_LENGTH_12_8 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_LENGTH_7_0 - Unsigned 13-bit RX Field 4 length value.
+//   PKT_RX_FIELD_4_CONFIG - General data processing and packet configuration bits for RX Field 4.
+//   PKT_RX_FIELD_4_CRC_CONFIG - Configuration of CRC control bits across RX Field 4.
+//   PKT_RX_FIELD_5_LENGTH_12_8 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_LENGTH_7_0 - Unsigned 13-bit RX Field 5 length value.
+//   PKT_RX_FIELD_5_CONFIG - General data processing and packet configuration bits for RX Field 5.
+//   PKT_RX_FIELD_5_CRC_CONFIG - Configuration of CRC control bits across RX Field 5.
+*/
+#define RF_PKT_RX_FIELD_3_CRC_CONFIG_9 0x11, 0x12, 0x09, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_MODEM_MOD_TYPE_12
+// Number of properties:     12
+// Group ID:                 0x20
+// Start ID:                 0x00
+// Default values:           0x02, 0x80, 0x07, 0x0F, 0x42, 0x40, 0x01, 0xC9, 0xC3, 0x80, 0x00, 0x06, 
+// Descriptions:
+//   MODEM_MOD_TYPE - Selects the type of modulation. In TX mode, additionally selects the source of the modulation.
+//   MODEM_MAP_CONTROL - Controls polarity and mapping of transmit and receive bits.
+//   MODEM_DSM_CTRL - Miscellaneous control bits for the Delta-Sigma Modulator (DSM) in the PLL Synthesizer.
+//   MODEM_DATA_RATE_2 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_1 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_DATA_RATE_0 - Unsigned 24-bit value used to determine the TX data rate
+//   MODEM_TX_NCO_MODE_3 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_2 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_1 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_TX_NCO_MODE_0 - TX Gaussian filter oversampling ratio and Byte 3 of unsigned 26-bit TX Numerically Controlled Oscillator (NCO) modulus.
+//   MODEM_FREQ_DEV_2 - 17-bit unsigned TX frequency deviation word.
+//   MODEM_FREQ_DEV_1 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_MOD_TYPE_12 0x11, 0x20, 0x0C, 0x00, 0x03, 0x00, 0x07, 0x1D, 0x4C, 0x00, 0x09, 0xC9, 0xC3, 0x80, 0x00, 0x0D
+
+/*
+// Set properties:           RF_MODEM_FREQ_DEV_0_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x0C
+// Default values:           0xD3, 
+// Descriptions:
+//   MODEM_FREQ_DEV_0 - 17-bit unsigned TX frequency deviation word.
+*/
+#define RF_MODEM_FREQ_DEV_0_1 0x11, 0x20, 0x01, 0x0C, 0x24
+
+/*
+// Set properties:           RF_MODEM_TX_RAMP_DELAY_8
+// Number of properties:     8
+// Group ID:                 0x20
+// Start ID:                 0x18
+// Default values:           0x01, 0x00, 0x08, 0x03, 0xC0, 0x00, 0x10, 0x20, 
+// Descriptions:
+//   MODEM_TX_RAMP_DELAY - TX ramp-down delay setting.
+//   MODEM_MDM_CTRL - MDM control.
+//   MODEM_IF_CONTROL - Selects Fixed-IF, Scaled-IF, or Zero-IF mode of RX Modem operation.
+//   MODEM_IF_FREQ_2 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_1 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_IF_FREQ_0 - the IF frequency setting (an 18-bit signed number).
+//   MODEM_DECIMATION_CFG1 - Specifies three decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+//   MODEM_DECIMATION_CFG0 - Specifies miscellaneous parameters and decimator ratios for the Cascaded Integrator Comb (CIC) filter.
+*/
+#define RF_MODEM_TX_RAMP_DELAY_8 0x11, 0x20, 0x08, 0x18, 0x01, 0x80, 0x08, 0x03, 0xC0, 0x00, 0x00, 0x20
+
+/*
+// Set properties:           RF_MODEM_BCR_OSR_1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x22
+// Default values:           0x00, 0x4B, 0x06, 0xD3, 0xA0, 0x06, 0xD3, 0x02, 0xC0, 
+// Descriptions:
+//   MODEM_BCR_OSR_1 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_OSR_0 - RX BCR/Slicer oversampling rate (12-bit unsigned number).
+//   MODEM_BCR_NCO_OFFSET_2 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_1 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_NCO_OFFSET_0 - RX BCR NCO offset value (an unsigned 22-bit number).
+//   MODEM_BCR_GAIN_1 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GAIN_0 - The unsigned 11-bit RX BCR loop gain value.
+//   MODEM_BCR_GEAR - RX BCR loop gear control.
+//   MODEM_BCR_MISC1 - Miscellaneous control bits for the RX BCR loop.
+*/
+#define RF_MODEM_BCR_OSR_1_9 0x11, 0x20, 0x09, 0x22, 0x00, 0x9C, 0x03, 0x46, 0xDC, 0x01, 0xA4, 0x02, 0xC2
+
+/*
+// Set properties:           RF_MODEM_AFC_GEAR_7
+// Number of properties:     7
+// Group ID:                 0x20
+// Start ID:                 0x2C
+// Default values:           0x00, 0x23, 0x83, 0x69, 0x00, 0x40, 0xA0, 
+// Descriptions:
+//   MODEM_AFC_GEAR - RX AFC loop gear control.
+//   MODEM_AFC_WAIT - RX AFC loop wait time control.
+//   MODEM_AFC_GAIN_1 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_GAIN_0 - Sets the gain of the PLL-based AFC acquisition loop, and provides miscellaneous control bits for AFC functionality.
+//   MODEM_AFC_LIMITER_1 - Set the AFC limiter value.
+//   MODEM_AFC_LIMITER_0 - Set the AFC limiter value.
+//   MODEM_AFC_MISC - Specifies miscellaneous AFC control bits.
+*/
+#define RF_MODEM_AFC_GEAR_7 0x11, 0x20, 0x07, 0x2C, 0x04, 0x36, 0x80, 0x8C, 0x07, 0x1D, 0x80
+
+/*
+// Set properties:           RF_MODEM_AGC_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x35
+// Default values:           0xE0, 
+// Descriptions:
+//   MODEM_AGC_CONTROL - Miscellaneous control bits for the Automatic Gain Control (AGC) function in the RX Chain.
+*/
+#define RF_MODEM_AGC_CONTROL_1 0x11, 0x20, 0x01, 0x35, 0xE2
+
+/*
+// Set properties:           RF_MODEM_AGC_WINDOW_SIZE_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x38
+// Default values:           0x11, 0x10, 0x10, 0x0B, 0x1C, 0x40, 0x00, 0x00, 0x2B, 
+// Descriptions:
+//   MODEM_AGC_WINDOW_SIZE - Specifies the size of the measurement and settling windows for the AGC algorithm.
+//   MODEM_AGC_RFPD_DECAY - Sets the decay time of the RF peak detectors.
+//   MODEM_AGC_IFPD_DECAY - Sets the decay time of the IF peak detectors.
+//   MODEM_FSK4_GAIN1 - Specifies the gain factor of the secondary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_GAIN0 - Specifies the gain factor of the primary branch in 4(G)FSK ISI-suppression.
+//   MODEM_FSK4_TH1 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_TH0 - 16 bit 4(G)FSK slicer threshold.
+//   MODEM_FSK4_MAP - 4(G)FSK symbol mapping code.
+//   MODEM_OOK_PDTC - Configures the attack and decay times of the OOK Peak Detector.
+*/
+#define RF_MODEM_AGC_WINDOW_SIZE_9 0x11, 0x20, 0x09, 0x38, 0x11, 0x22, 0x22, 0x00, 0x1A, 0x80, 0x55, 0x00, 0x29
+
+/*
+// Set properties:           RF_MODEM_OOK_CNT1_9
+// Number of properties:     9
+// Group ID:                 0x20
+// Start ID:                 0x42
+// Default values:           0xA4, 0x03, 0x56, 0x02, 0x00, 0xA3, 0x02, 0x80, 0xFF, 
+// Descriptions:
+//   MODEM_OOK_CNT1 - OOK control.
+//   MODEM_OOK_MISC - Selects the detector(s) used for demodulation of an OOK signal, or for demodulation of a (G)FSK signal when using the asynchronous demodulator.
+//   MODEM_RAW_SEARCH - Defines and controls the search period length for the Moving Average and Min-Max detectors.
+//   MODEM_RAW_CONTROL - Defines gain and enable controls for raw / nonstandard mode.
+//   MODEM_RAW_EYE_1 - 11 bit eye-open detector threshold.
+//   MODEM_RAW_EYE_0 - 11 bit eye-open detector threshold.
+//   MODEM_ANT_DIV_MODE - Antenna diversity mode settings.
+//   MODEM_ANT_DIV_CONTROL - Specifies controls for the Antenna Diversity algorithm.
+//   MODEM_RSSI_THRESH - Configures the RSSI threshold.
+*/
+#define RF_MODEM_OOK_CNT1_9 0x11, 0x20, 0x09, 0x42, 0xA4, 0x02, 0xD6, 0x83, 0x00, 0xD0, 0x01, 0x80, 0xFF
+
+/*
+// Set properties:           RF_MODEM_RSSI_CONTROL_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4C
+// Default values:           0x01, 
+// Descriptions:
+//   MODEM_RSSI_CONTROL - Control of the averaging modes and latching time for reporting RSSI value(s).
+*/
+#define RF_MODEM_RSSI_CONTROL_1 0x11, 0x20, 0x01, 0x4C, 0x00
+
+/*
+// Set properties:           RF_MODEM_RSSI_COMP_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x4E
+// Default values:           0x32, 
+// Descriptions:
+//   MODEM_RSSI_COMP - RSSI compensation value.
+*/
+#define RF_MODEM_RSSI_COMP_1 0x11, 0x20, 0x01, 0x4E, 0x40
+
+/*
+// Set properties:           RF_MODEM_CLKGEN_BAND_1
+// Number of properties:     1
+// Group ID:                 0x20
+// Start ID:                 0x51
+// Default values:           0x08, 
+// Descriptions:
+//   MODEM_CLKGEN_BAND - Select PLL Synthesizer output divider ratio as a function of frequency band.
+*/
+#define RF_MODEM_CLKGEN_BAND_1 0x11, 0x20, 0x01, 0x51, 0x08
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x00
+// Default values:           0xFF, 0xBA, 0x0F, 0x51, 0xCF, 0xA9, 0xC9, 0xFC, 0x1B, 0x1E, 0x0F, 0x01, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE13_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE12_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE11_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE10_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE9_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE8_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE7_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE6_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE5_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE4_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE3_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE2_7_0 - Filter coefficients for the first set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12 0x11, 0x21, 0x0C, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x0C
+// Default values:           0xFC, 0xFD, 0x15, 0xFF, 0x00, 0x0F, 0xFF, 0xC4, 0x30, 0x7F, 0xF5, 0xB5, 
+// Descriptions:
+//   MODEM_CHFLT_RX1_CHFLT_COE1_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COE0_7_0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM0 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM1 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM2 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX1_CHFLT_COEM3 - Filter coefficients for the first set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE13_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE12_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE11_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE10_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE9_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE8_7_0 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12 0x11, 0x21, 0x0C, 0x0C, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00, 0xCC, 0xA1, 0x30, 0xA0, 0x21, 0xD1
+
+/*
+// Set properties:           RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12
+// Number of properties:     12
+// Group ID:                 0x21
+// Start ID:                 0x18
+// Default values:           0xB8, 0xDE, 0x05, 0x17, 0x16, 0x0C, 0x03, 0x00, 0x15, 0xFF, 0x00, 0x00, 
+// Descriptions:
+//   MODEM_CHFLT_RX2_CHFLT_COE7_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE6_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE5_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE4_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE3_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE2_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE1_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COE0_7_0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM0 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM1 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM2 - Filter coefficients for the second set of RX filter coefficients.
+//   MODEM_CHFLT_RX2_CHFLT_COEM3 - Filter coefficients for the second set of RX filter coefficients.
+*/
+#define RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12 0x11, 0x21, 0x0C, 0x18, 0xB9, 0xC9, 0xEA, 0x05, 0x12, 0x11, 0x0A, 0x04, 0x15, 0xFC, 0x03, 0x00
+
+/*
+// Set properties:           RF_PA_MODE_4
+// Number of properties:     4
+// Group ID:                 0x22
+// Start ID:                 0x00
+// Default values:           0x08, 0x7F, 0x00, 0x5D, 
+// Descriptions:
+//   PA_MODE - Selects the PA operating mode, and selects resolution of PA power adjustment (i.e., step size).
+//   PA_PWR_LVL - Configuration of PA output power level.
+//   PA_BIAS_CLKDUTY - Configuration of the PA Bias and duty cycle of the TX clock source.
+//   PA_TC - Configuration of PA ramping parameters.
+*/
+#define RF_PA_MODE_4 0x11, 0x22, 0x04, 0x00, 0x08, 0x7F, 0x00, 0x3D
+
+/*
+// Set properties:           RF_SYNTH_PFDCP_CPFF_7
+// Number of properties:     7
+// Group ID:                 0x23
+// Start ID:                 0x00
+// Default values:           0x2C, 0x0E, 0x0B, 0x04, 0x0C, 0x73, 0x03, 
+// Descriptions:
+//   SYNTH_PFDCP_CPFF - Feed forward charge pump current selection.
+//   SYNTH_PFDCP_CPINT - Integration charge pump current selection.
+//   SYNTH_VCO_KV - Gain scaling factors (Kv) for the VCO tuning varactors on both the integrated-path and feed forward path.
+//   SYNTH_LPFILT3 - Value of resistor R2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT2 - Value of capacitor C2 in feed-forward path of loop filter.
+//   SYNTH_LPFILT1 - Value of capacitors C1 and C3 in feed-forward path of loop filter.
+//   SYNTH_LPFILT0 - Bias current of the active amplifier in the feed-forward loop filter.
+*/
+#define RF_SYNTH_PFDCP_CPFF_7 0x11, 0x23, 0x07, 0x00, 0x34, 0x04, 0x0B, 0x04, 0x07, 0x70, 0x03
+
+/*
+// Set properties:           RF_MATCH_VALUE_1_12
+// Number of properties:     12
+// Group ID:                 0x30
+// Start ID:                 0x00
+// Default values:           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+// Descriptions:
+//   MATCH_VALUE_1 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 1 value with the received Match 1 byte.
+//   MATCH_MASK_1 - Mask value to be logically AND-ed (bit-wise) with the Match 1 byte.
+//   MATCH_CTRL_1 - Enable for Packet Match functionality, and configuration of Match Byte 1.
+//   MATCH_VALUE_2 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 2 value with the received Match 2 byte.
+//   MATCH_MASK_2 - Mask value to be logically AND-ed (bit-wise) with the Match 2 byte.
+//   MATCH_CTRL_2 - Configuration of Match Byte 2.
+//   MATCH_VALUE_3 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 3 value with the received Match 3 byte.
+//   MATCH_MASK_3 - Mask value to be logically AND-ed (bit-wise) with the Match 3 byte.
+//   MATCH_CTRL_3 - Configuration of Match Byte 3.
+//   MATCH_VALUE_4 - Match value to be compared with the result of logically AND-ing (bit-wise) the Mask 4 value with the received Match 4 byte.
+//   MATCH_MASK_4 - Mask value to be logically AND-ed (bit-wise) with the Match 4 byte.
+//   MATCH_CTRL_4 - Configuration of Match Byte 4.
+*/
+#define RF_MATCH_VALUE_1_12 0x11, 0x30, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+
+/*
+// Set properties:           RF_FREQ_CONTROL_INTE_8
+// Number of properties:     8
+// Group ID:                 0x40
+// Start ID:                 0x00
+// Default values:           0x3C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0xFF, 
+// Descriptions:
+//   FREQ_CONTROL_INTE - Frac-N PLL Synthesizer integer divide number.
+//   FREQ_CONTROL_FRAC_2 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_1 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_FRAC_0 - Frac-N PLL fraction number.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_1 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_CHANNEL_STEP_SIZE_0 - EZ Frequency Programming channel step size.
+//   FREQ_CONTROL_W_SIZE - Set window gating period (in number of crystal reference clock cycles) for counting VCO frequency during calibration.
+//   FREQ_CONTROL_VCOCNT_RX_ADJ - Adjust target count for VCO calibration in RX mode.
+*/
+#define RF_FREQ_CONTROL_INTE_8 0x11, 0x40, 0x08, 0x00, 0x3C, 0x08, 0x00, 0x00, 0x22, 0x22, 0x20, 0xFF
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x06, RF_GLOBAL_XO_TUNE_2, \
+        0x05, RF_GLOBAL_CONFIG_1, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x0D, RF_PREAMBLE_TX_LENGTH_9, \
+        0x09, RF_SYNC_CONFIG_5, \
+        0x0B, RF_PKT_CRC_CONFIG_7, \
+        0x10, RF_PKT_LEN_12, \
+        0x10, RF_PKT_FIELD_2_CRC_CONFIG_12, \
+        0x10, RF_PKT_FIELD_5_CRC_CONFIG_12, \
+        0x0D, RF_PKT_RX_FIELD_3_CRC_CONFIG_9, \
+        0x10, RF_MODEM_MOD_TYPE_12, \
+        0x05, RF_MODEM_FREQ_DEV_0_1, \
+        0x0C, RF_MODEM_TX_RAMP_DELAY_8, \
+        0x0D, RF_MODEM_BCR_OSR_1_9, \
+        0x0B, RF_MODEM_AFC_GEAR_7, \
+        0x05, RF_MODEM_AGC_CONTROL_1, \
+        0x0D, RF_MODEM_AGC_WINDOW_SIZE_9, \
+        0x0D, RF_MODEM_OOK_CNT1_9, \
+        0x05, RF_MODEM_RSSI_CONTROL_1, \
+        0x05, RF_MODEM_RSSI_COMP_1, \
+        0x05, RF_MODEM_CLKGEN_BAND_1, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE13_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX1_CHFLT_COE1_7_0_12, \
+        0x10, RF_MODEM_CHFLT_RX2_CHFLT_COE7_7_0_12, \
+        0x08, RF_PA_MODE_4, \
+        0x0B, RF_SYNTH_PFDCP_CPFF_7, \
+        0x10, RF_MATCH_VALUE_1_12, \
+        0x0C, RF_FREQ_CONTROL_INTE_8, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT					   {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,       \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                   \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */


### PR DESCRIPTION
## Summary
- Add data/conf_Si1060_30MHz/ directory containing 30MHz Si1060 configuration headers restored from master
