### PR TITLE
Isolate Si446x radio configuration per board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .metadata
 Firmware/bootloader/obj
 Firmware/radio/obj
-Firmware/radio/radio_446x_conf.h
 Firmware/.cproject
 Firmware/.project
 SiKUploader/uploader/bin

--- a/Firmware/include/rules.mk
+++ b/Firmware/include/rules.mk
@@ -64,12 +64,14 @@ DSTROOT		?=	$(SRCROOT)/dst
 
 SI446X_CONFIG_DIR       ?=      $(SRCROOT)/../data/conf_Si1060_30MHz
 SI446X_TOOL             :=      $(SRCROOT)/tools/build_si446x_table.py
-RADIO_CONF_DIR          :=      $(SRCROOT)/radio
+RADIO_INCLUDE_DIR       :=      $(SRCROOT)/radio
+RADIO_CONF_DIR          :=      $(OBJROOT)/generated
 RADIO_CONF              :=      $(RADIO_CONF_DIR)/radio_446x_conf.h
 SI446X_HEADERS          :=      $(sort $(wildcard $(SI446X_CONFIG_DIR)/*.h))
 
 # Ensure the generated configuration is available before compiling sources.
 GLOBAL_DEPS     +=      $(RADIO_CONF)
+CFLAGS          +=      -I$(RADIO_INCLUDE_DIR)
 CFLAGS          +=      -I$(RADIO_CONF_DIR)
 
 
@@ -101,7 +103,7 @@ DEPFLAGS	 =	-MM $(CFLAGS)
 
 $(RADIO_CONF): $(SI446X_TOOL) $(SI446X_HEADERS)
 	@echo GEN $@
-	@mkdir -p $(RADIO_CONF_DIR)
+	@mkdir -p $(dir $@)
 	$(v)$(PYTHON) $(SI446X_TOOL) --config-dir $(SI446X_CONFIG_DIR) --output $@
 
 ifeq ($(INCLUDE_AES),1)

--- a/Firmware/tools/build_si446x_table.py
+++ b/Firmware/tools/build_si446x_table.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# This script generates radio/radio_446x_conf.h
+# This script generates a board-specific radio_446x_conf.h
 # Copyright (c) 2022 ThunderFly s.r.o., All Rights Reserved
 #
 # Silabs' WDS software allows to export a header file containing register values

--- a/data/readme.md
+++ b/data/readme.md
@@ -2,6 +2,7 @@ The directories conf_Si1060_26MHz and conf_Si1060_30MHz contain configuration he
 
 The firmware build regenerates the radio configuration header on demand. The helper script supports selecting the desired header set explicitly, e.g.:
 
-    ../../Firmware/tools/build_si446x_table.py --config-dir conf_Si1060_30MHz --output ../../Firmware/radio/radio_446x_conf.h
+    ../../Firmware/tools/build_si446x_table.py --config-dir conf_Si1060_30MHz --output ../../Firmware/obj/<BOARD>/<PRODUCT>/generated/radio_446x_conf.h
 
-Adjust the --config-dir argument to point to either the 26 MHz or 30 MHz directory when regenerating the table manually.
+Adjust the --config-dir argument to point to either the 26 MHz or 30 MHz directory when regenerating the table manually, and
+replace the placeholder path components in the --output argument with the desired build output directory.


### PR DESCRIPTION
## Summary
- store the generated Si446x configuration header under a board-specific output directory and add it to the compiler include path
- ensure the configuration rule creates its destination directory before regenerating the table
- refresh documentation and repository metadata to reference the new per-board header location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d81f7d12388322b23268e951acf2db