### PR TITLE
Add CW AT test mode for continuous carrier testing

### DIFF
--- a/Firmware/radio/at.c
+++ b/Firmware/radio/at.c
@@ -436,12 +436,15 @@ at_ampersand(void)
 		} else if (!strcmp(at_cmd + 4, "=RSSI")) {
 			// display RSSI stats
 			at_testmode ^= AT_TEST_RSSI;
-		} else if (!strcmp(at_cmd + 4, "=TDM")) {
-			// display TDM debug
-			at_testmode ^= AT_TEST_TDM;
-		} else {
-			at_error();
-		}
+                } else if (!strcmp(at_cmd + 4, "=TDM")) {
+                        // display TDM debug
+                        at_testmode ^= AT_TEST_TDM;
+                } else if (!strcmp(at_cmd + 4, "=CW")) {
+                        // continuous wave transmit test
+                        at_testmode ^= AT_TEST_CW;
+                } else {
+                        at_error();
+                }
 		break;
 #ifdef INCLUDE_AES
   case 'E':

--- a/Firmware/radio/at.h
+++ b/Firmware/radio/at.h
@@ -73,6 +73,7 @@ extern __pdata uint8_t  at_testmode;    ///< AT_TEST_* bits
 
 #define AT_TEST_RSSI 1
 #define AT_TEST_TDM  2
+#define AT_TEST_CW   4
 
 // max size of an AT command
 #ifdef CPU_SI1030

--- a/Firmware/radio/radio.h
+++ b/Firmware/radio/radio.h
@@ -183,6 +183,12 @@ extern bool radio_transmit(uint8_t length, __xdata uint8_t * __pdata buf, __pdat
 ///
 extern bool radio_receiver_on(void);
 
+/// start continuous wave test transmission
+extern void radio_test_cw_start(void);
+
+/// stop continuous wave test transmission
+extern void radio_test_cw_stop(void);
+
 /// reset and intiialise the radio
 ///
 /// @return			True if the initialisation completed successfully.

--- a/Firmware/radio/radio_443x.c
+++ b/Firmware/radio/radio_443x.c
@@ -538,6 +538,18 @@ radio_transmit(uint8_t length, __xdata uint8_t * __pdata buf, __pdata uint16_t t
 }
 
 
+void
+radio_test_cw_start(void)
+{
+        /* Continuous wave uses the normal transmit path, no setup required. */
+}
+
+void
+radio_test_cw_stop(void)
+{
+        /* Nothing to clean up when leaving CW mode. */
+}
+
 // put the radio in receive mode
 //
 bool

--- a/Firmware/radio/radio_446x.c
+++ b/Firmware/radio/radio_446x.c
@@ -531,6 +531,22 @@ radio_transmit(uint8_t length, __xdata uint8_t * __pdata buf, __pdata uint16_t t
 	return ret;
 }
 
+void
+radio_test_cw_start(void)
+{
+        /* Continuous wave uses the standard transmit path, no setup required. */
+}
+
+void
+radio_test_cw_stop(void)
+{
+        /* Ensure the radio is not left in TX state when stopping CW mode. */
+        EX0_SAVE_DISABLE;
+        cmd_change_state(STATE_READY);
+        wait_for_cts();
+        EX0_RESTORE;
+}
+
 static void
 _radio_receiver_on(void) __reentrant
 {

--- a/Firmware/radio/tdm.c
+++ b/Firmware/radio/tdm.c
@@ -56,6 +56,10 @@ __pdata static enum tdm_state tdm_state;
 /// a packet buffer for the TDM code
 __xdata uint8_t	pbuf[MAX_PACKET_LENGTH];
 
+/// buffer used for continuous wave transmissions
+static __xdata uint8_t cw_packet[MAX_PACKET_LENGTH];
+static bool cw_packet_initialised;
+
 /// how many 16usec ticks are remaining in the current state
 __pdata static uint16_t tdm_state_remaining;
 
@@ -507,6 +511,7 @@ tdm_serial_loop(void)
         //radio_receiver_on();
     }
 #else
+  static bool cw_active;
   __pdata uint8_t	len;
   __pdata uint16_t tnow, tdelta;
   __pdata uint8_t max_xmit;
@@ -531,6 +536,36 @@ tdm_serial_loop(void)
     // give the AT command processor a chance to handle a command
     at_command();
     
+    if (at_testmode & AT_TEST_CW) {
+      uint32_t cw_timeout = packet_latency + ((uint32_t)MAX_PACKET_LENGTH * (uint32_t)ticks_per_byte);
+      if (!cw_packet_initialised) {
+        memset(cw_packet, 0x00, sizeof(cw_packet));
+        cw_packet_initialised = true;
+      }
+      if (!cw_active) {
+        radio_set_channel(fhop_transmit_channel());
+        radio_test_cw_start();
+        cw_active = true;
+        transmit_wait = 0;
+        bonus_transmit = 0;
+        transmit_yield = 0;
+        last_t = timer2_tick();
+        last_link_update = last_t;
+      }
+      if (cw_timeout > 0xFFFFUL) {
+        cw_timeout = 0xFFFFUL;
+      }
+      radio_transmit(MAX_PACKET_LENGTH, cw_packet, (uint16_t)cw_timeout);
+      continue;
+    } else if (cw_active) {
+      radio_test_cw_stop();
+      radio_receiver_on();
+      cw_active = false;
+      last_t = timer2_tick();
+      last_link_update = last_t;
+      continue;
+    }
+
     // display test data if needed
     if (test_display) {
       display_test_output();

--- a/README.markdown
+++ b/README.markdown
@@ -57,7 +57,7 @@ During initial startup or after a link is lost, the radios enter a scanning mode
 |AT&W| | Write parameters to the flash memory | 
 |AT&U | | Erase Flash signature forcing it into reprogram mode next reset |
 |AT&P | | TDM change phase |
-|AT&T | AT&T <br> AT&T=RSSI <br> AT&T=TDM |  disable all test modes <br> display RSSI stats <br> display TDM debug |
+|AT&T | AT&T <br> AT&T=RSSI <br> AT&T=TDM <br> AT&T=CW |  disable all test modes <br> display RSSI stats <br> display TDM debug <br> toggle continuous wave transmit mode for carrier measurements |
 |AT&E | AT&E?  <br> AT&E= | Print_encryption_key <br> Set encryption key | 
 |AT+ | AT+P= <br> AT+Cx=y <br> AT+Fx? <br> AT+L <br> AT+A |  set power level PWR to x immediately <br>  write calibration value <br> get calibration value <br> lock bootloader area if all calibrations written <br> Select antenna and override diversity  |
 |ATI0| | banner_string |


### PR DESCRIPTION
## Summary
- add an AT&T=CW toggle and expose the new CW test helper hooks
- drive the TDM loop into a transmit-only mode that reuses the existing packet sender for CW
- document the new AT command in the README for measurement guidance
