### PR TITLE
Fix intermittent timeout in rssi.py

### DIFF
--- a/Firmware/tools/rssi.py
+++ b/Firmware/tools/rssi.py
@@ -17,6 +17,15 @@ if len(args) == 0:
     sys.exit(1)
 
 
+def flush(ser):
+    '''discard everything currently pending, both in pexpect's own buffer
+    and in the underlying serial input buffer'''
+    try:
+        ser.expect(fdpexpect.TIMEOUT, timeout=0.5)
+    except fdpexpect.EOF:
+        pass
+
+
 def rssi(device):
     port = serial.Serial(
         device,
@@ -27,18 +36,28 @@ def rssi(device):
         xonxoff=opts.xonxoff
     )
 
-    ser = fdpexpect.fdspawn(port.fileno(), logfile=sys.stdout, encoding="latin-1")
+    ser = fdpexpect.fdspawn(port.fileno(), encoding="latin-1")
+    # logfile_read (not logfile) so we echo only what the modem sends back,
+    # otherwise every command we send is printed twice.
+    ser.logfile_read = sys.stdout
     ser.send('+++')
     time.sleep(1)
+    # '+++' makes the modem print "OK" and switch to command mode. Drop that
+    # reply (and any stale line noise) so the ATI response below is matched
+    # against the version banner only, not against the leftover "OK".
+    flush(ser)
     ser.send('\r\nATI\r\n')
     try:
-        ser.expect(['OK','SiK .*'], timeout=2)
+        ser.expect('SiK .*', timeout=2)
     except fdpexpect.TIMEOUT:
         print("timeout")
         return
+    # Let the banner finish and drain it; otherwise AT&F is sent while the
+    # modem is still transmitting and is received corrupted.
+    flush(ser)
     ser.send('AT&F\r\n')
     try:
-        ser.expect(['OK'], timeout=2)
+        ser.expect('OK', timeout=2)
     except fdpexpect.TIMEOUT:
         print("timeout")
         return


### PR DESCRIPTION
## Fix intermittent timeout and doubled echo in `rssi.py`

### Problem
  `Firmware/tools/rssi.py` would occasionally fail on `timeout` at startup, while a subsequent run would succeed. 

  ### Root cause
  The `+++` sequence switches the modem into command mode, which makes it print `OK`. The first `expect(['OK', 'SiK .*'])` matched that `OK` — not the response to `ATI`. This shifted the whole flow by one
  response: `AT&F` was sent while the modem was still emitting the banner, arrived corrupted (`&F`), and the modem never replied `OK` → timeout. Re-running masked the bug because the modem was already in a clean state.

  ### Fix
  - Flush the input buffer after `+++` (`flush()`), discarding the `OK` from `+++` and any line noise.
  - Synchronize on the `SiK .*` banner instead of `OK`, which guarantees that `ATI` actually completed.
  - Let the banner finish and drain the buffer before sending `AT&F`, so the command isn't received corrupted.

  ### Verification
  Tested against a real modem (`/dev/ttyUSB0`, TFSIK01 30MHz, 57600 Bd). The output is now clean and reliably repeatable:

  Putting /dev/ttyUSB0 into rssi test mode
  +++
  ATI
  SiK tf250927-2-4-g7a56934 on TFSIK01 30MHz
  AT&F
  OK
  AT&T=RSSI
  L/R RSSI: 118/110  L/R noise: 72/51 pkts: 4424  txe=0 rxe=2 stx=0 srx=0 ecc=0/0 temp=0 dco=0
  ...
